### PR TITLE
Fix: dataset_tool.py conditional subdirs

### DIFF
--- a/src/dataset_tool.py
+++ b/src/dataset_tool.py
@@ -319,7 +319,12 @@ def convert_dataset(
     labels = []
     for idx, image in tqdm(enumerate(input_iter), total=num_files):
         idx_str = f'{idx:08d}'
-        archive_fname = f'{idx_str[:5]}/img{idx_str}.png'
+        idx_label = image['label']
+
+        if idx_label is not None:
+            archive_fname = f'{idx_label:05d}/img{idx_str}.png'
+        else:
+            archive_fname = f'{idx_str[:5]}/img{idx_str}.png'
 
         # Apply crop and resize.
         if width is not None or height is not None:
@@ -360,7 +365,6 @@ def convert_dataset(
         img.save(image_bits, format='png', compress_level=0, optimize=False)
         save_bytes(os.path.join(archive_root_dir, archive_fname), image_bits.getbuffer())
         labels.append([archive_fname, image['label']] if image['label'] is not None else None)
-        print(image['label'])
 
     metadata = {
         'labels': labels if all(x is not None for x in labels) else None


### PR DESCRIPTION
It seems that your fork uses subdirs for a conditional model. When building dataset database in a .zip file using dataset_tool.py the subdirs are based on `idx_str` so have nothing to do with the categories that were defined in the dataset.json consequently the shape of the labels is incorrect (I was seeing label shape [3] for 2 categories) 

This PR uses the category as a directory name inside the zip, so that the label shape is reported correctly. This then replicates the behaviour if you supply a directory instead of zip.